### PR TITLE
Fixed shots bug in Player.cs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: c#

--- a/battships-C#/src/Model/Player.cs
+++ b/battships-C#/src/Model/Player.cs
@@ -181,18 +181,22 @@ public class Player : IEnumerable<Ship>
 	/// <returns>the result of the attack</returns>
 	internal AttackResult Shoot(int row, int col)
 	{
-		_shots += 1;
-		AttackResult result = default(AttackResult);
+        
+        AttackResult result = default(AttackResult);
 		result = EnemyGrid.HitTile(row, col);
 
 		switch (result.Value) {
 			case ResultOfAttack.Destroyed:
 			case ResultOfAttack.Hit:
 				_hits += 1;
-				break;
+                _shots += 1;
+                break;
 			case ResultOfAttack.Miss:
 				_misses += 1;
-				break;
+                _shots += 1;
+                break;
+            case ResultOfAttack.ShotAlready:
+                break;
 		}
 
 		return result;


### PR DESCRIPTION
In Player.cs, Shoot(), the _shots++ line is moved into the switch cases. Previously, it was outside the cases which meant that the _shots variable was incremented regardless of the switch case.